### PR TITLE
fix: copy2->copy to support cross-filesystem/network paths

### DIFF
--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -25,7 +25,7 @@ def copy_files_skip_existing(src_dir, dst_dir):
             if os.path.exists(dst_path):
                 skipped += 1
             else:
-                shutil.copy2(src_path, dst_path)
+                shutil.copy(src_path, dst_path)
                 copied += 1
         elif os.path.isdir(src_path):
             # Recursively copy directories
@@ -65,7 +65,7 @@ def main():
                     if dst_path.exists():
                         skipped += 1
                     else:
-                        shutil.copy2(str(src_path), str(dst_path))
+                        shutil.copy(str(src_path), str(dst_path))
                         copied += 1
         print(f"[SAM3] Image assets: {copied} copied, {skipped} skipped")
     else:


### PR DESCRIPTION
Hello,

Thanks for providing your wonderful SAM3 wrapper.  

There is a slight issue with the use of `shutil.copy2` versus `shutil.copy`.  `copy2` fails if it cannot preserve metadata (like timestamps), so if files are stored on an NTFS share, bind mount, or network location (common for WSL or containerized users), the startup script crashes.  

This patch simply replaces `copy2` with `copy` in the prestartup script to ensure compatibility across filesystems.