### PR TITLE
Enable loading in half precision

### DIFF
--- a/nodes/load_model.py
+++ b/nodes/load_model.py
@@ -160,13 +160,13 @@ class SAM3UnifiedModel(SAM3ModelPatcher):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-    def clear_position_encoding_caches(self, model) -> None:
+    def clear_caches(self, model) -> None:
         if model is None:
             return
         if hasattr(model, 'clear_cache') and callable(model.clear_cache):
             model.clear_cache()
         for child_name, child_module in model.named_children():
-            self.clear_position_encoding_caches(child_module)
+            self.clear_caches(child_module)
 
 
 class LoadSAM3Model:

--- a/nodes/sam3_video_nodes.py
+++ b/nodes/sam3_video_nodes.py
@@ -502,6 +502,7 @@ class SAM3Propagate:
             print("[SAM3 Video] Offloading model to CPU to free VRAM...")
             if hasattr(sam3_model, 'model'):
                 sam3_model.model.cpu()
+                sam3_model.clear_caches(sam3_model.model)
             # Clear inference state cache to free GPU memory
             from .sam3_lib.sam3_video_predictor import Sam3VideoPredictor
             Sam3VideoPredictor._ALL_INFERENCE_STATES.clear()

--- a/nodes/segmentation.py
+++ b/nodes/segmentation.py
@@ -150,6 +150,7 @@ class SAM3Grounding:
         if offload_model:
             print("[SAM3 Grounding] Offloading model to CPU to free VRAM...")
             sam3_model.unpatch_model()
+            sam3_model.clear_caches(sam3_model.model)
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
@@ -760,6 +761,7 @@ class SAM3Segmentation:
         if offload_model:
             print("[SAM3 Segmentation] Offloading model to CPU to free VRAM...")
             sam3_model.unpatch_model()
+            sam3_model.clear_caches(sam3_model.model)
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()


### PR DESCRIPTION
I noticed there already were functions for setting autocast dtype depending on GPU capability. However, they were restricted to compute major version >= 7 whereas my GPU with compute 5.2 can also run models in float16, and in fact it is the only way to run SAM3 because it crashes with OOM if loading in float32 with 4 GB VRAM. I don't know if compute 6.x devices are good with float16 so the detection rule could be tuned further if they have problems.

I moved dtype detection into load_model, save it with the sam3_model and subsequently use it to autocast accordingly. Loading the video model with `.half()` is the key change to reduce memory use, but the autocasts are necessary to prevent tensor type mismatch errors during processing. I hope I caught them for all use cases...

The interactive detection dialog doesn't use the same loaded model so I added separate detection for it.