### PR TITLE
Added multi_prompts input for Video Segmentation

### DIFF
--- a/web/sam3_multiregion_widget.js
+++ b/web/sam3_multiregion_widget.js
@@ -248,12 +248,14 @@ app.registerExtension({
 
             canvas.addEventListener("contextmenu", (e) => {
                 e.preventDefault();
-                canvas.dispatchEvent(new MouseEvent('mousedown', {
-                    button: 2,
-                    clientX: e.clientX,
-                    clientY: e.clientY,
-                    shiftKey: e.shiftKey
-                }));
+                // Right-click already triggers native mousedown(button=2).
+                // Keep this block disabled to avoid adding duplicate negative points.
+                // canvas.dispatchEvent(new MouseEvent('mousedown', {
+                //     button: 2,
+                //     clientX: e.clientX,
+                //     clientY: e.clientY,
+                //     shiftKey: e.shiftKey
+                // }));
             });
 
             // Handle image loading


### PR DESCRIPTION
This change adds multi-prompt input support for video segmentation, enabling multiple objects to be tracked in a single run. A new multi prompt mode accepts SAM3_MULTI_PROMPTS, converts each prompt region into per-object video prompts (points/boxes), and handles multiple boxes per object. The UI now shows the multi_prompts input when prompt_mode=multi, and multi_prompts input will auto-switch the node into multi mode.
<img width="1655" height="930" alt="image" src="https://github.com/user-attachments/assets/83b53ed1-167b-4635-a87a-3a5be68cad77" />
