### PR TITLE
Add multi_prompts input for Video Segmentation + fix right-click duplicate points bug

### DIFF
--- a/web/sam3_multiregion_widget.js
+++ b/web/sam3_multiregion_widget.js
@@ -248,12 +248,14 @@ app.registerExtension({
 
             canvas.addEventListener("contextmenu", (e) => {
                 e.preventDefault();
-                canvas.dispatchEvent(new MouseEvent('mousedown', {
-                    button: 2,
-                    clientX: e.clientX,
-                    clientY: e.clientY,
-                    shiftKey: e.shiftKey
-                }));
+                // Right-click already triggers native mousedown(button=2).
+                // Keep this block disabled to avoid adding duplicate negative points.
+                // canvas.dispatchEvent(new MouseEvent('mousedown', {
+                //     button: 2,
+                //     clientX: e.clientX,
+                //     clientY: e.clientY,
+                //     shiftKey: e.shiftKey
+                // }));
             });
 
             // Handle image loading


### PR DESCRIPTION
This PR re-submits the multi-prompts feature originally in PR #83 (closed due to upstream main force-push history rewrite), with key updates:
- Added `multi_prompts` input support for video segmentation, enabling multi-object tracking in a single run. It supports `SAM3_MULTI_PROMPTS` format, converts prompt regions to per-object video prompts, and auto-switches to multi mode when `multi_prompts` is used.

- Fixed the bug where right-clicking in `sam3_multiregion_widget.js` added 2 duplicate points by removing overlapping right-click event handlers.

<img width="1655" height="930" alt="544715131-83b53ed1-167b-4635-a87a-3a5be68cad77" src="https://github.com/user-attachments/assets/d114bfe3-3a71-4208-9fbd-19a3f4e2832e" />
