### PR TITLE
Bump safetensors requirement to >=0.7.0 for C64 dtype support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ comfy-env==0.2.10
 comfy-3d-viewers==0.2.27
 
 # SAM3 dependencies (vendored in sam3/)
-safetensors>=0.4.0
+safetensors>=0.7.0
 timm>=1.0.17
 ftfy==6.1.1
 regex


### PR DESCRIPTION
The SAM3 model checkpoint contains complex64 (C64) tensors which are only supported in safetensors 0.7.0+. Earlier versions fail with: "unknown variant C64" when loading the model.