### PR TITLE
Fix mmap file locking error on Windows when changing obj_id

### DIFF
--- a/nodes/sam3_video_nodes.py
+++ b/nodes/sam3_video_nodes.py
@@ -715,8 +715,11 @@ class SAM3VideoOutput:
         # ============================================================
         # STREAMING: Create memory-mapped files on disk
         # Data is written directly to disk, not accumulated in RAM
+        # Use unique subdir per (obj_id, plot_all_masks) to avoid
+        # Windows file locking when previous mmaps are still cached.
         # ============================================================
-        mmap_dir = os.path.join(video_state.temp_dir, "mmap_output")
+        mmap_subdir = f"mmap_obj{obj_id}_{'all' if plot_all_masks else 'single'}"
+        mmap_dir = os.path.join(video_state.temp_dir, mmap_subdir)
         os.makedirs(mmap_dir, exist_ok=True)
 
         mask_path = os.path.join(mmap_dir, "masks.mmap")


### PR DESCRIPTION
## Summary
- On Windows, `numpy.memmap` files cannot be reopened for writing while still memory-mapped by cached tensors
- When `obj_id` changes in SAM3VideoOutput, the cache key misses but the code tries to recreate mmap files at the same path (`mmap_output/masks.mmap`), causing `OSError [Errno 22] Invalid argument`
- Fix: use unique mmap subdirectories per `(obj_id, plot_all_masks)` combination (e.g. `mmap_obj0_all/`, `mmap_obj1_all/`) so cached mmaps don't block new ones

## Test plan
- Run SAM3 video propagation with obj_id=0, verify it works
- Change obj_id to 1 (or any other value), queue prompt again
- Verify it completes without `[Errno 22]` error