### PR TITLE
Fix SAM3 loading in desktop ComfyUI installs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,7 @@
+from .nodes._comfyui_bootstrap import ensure_comfyui_base
 from comfy_env import register_nodes
 
+ensure_comfyui_base()
 NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS = register_nodes()
 
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -7,6 +7,10 @@ Version 3.0.0 refactoring:
 - Automatic cleanup (no manual SAM3CloseVideoSession needed)
 """
 
+from ._comfyui_bootstrap import ensure_comfyui_base
+
+ensure_comfyui_base()
+
 from .load_model import NODE_CLASS_MAPPINGS as LOAD_MODEL_MAPPINGS
 from .load_model import NODE_DISPLAY_NAME_MAPPINGS as LOAD_MODEL_DISPLAY_MAPPINGS
 from .segmentation import NODE_CLASS_MAPPINGS as SEGMENTATION_MAPPINGS

--- a/nodes/_comfyui_bootstrap.py
+++ b/nodes/_comfyui_bootstrap.py
@@ -1,0 +1,76 @@
+"""
+Helpers for finding ComfyUI core modules from comfy-env isolation workers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _is_comfyui_base(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and (path / "folder_paths.py").exists()
+        and (path / "comfy_api").is_dir()
+    )
+
+
+def _candidate_paths() -> list[Path]:
+    candidates: list[Path] = []
+
+    for key in ("COMFYUI_BASE", "COMFYUI_PATH", "COMFYUI_DIR"):
+        value = os.environ.get(key)
+        if value:
+            candidates.append(Path(value))
+
+    host_python_dir = os.environ.get("COMFYUI_HOST_PYTHON_DIR")
+    if host_python_dir:
+        host_dir = Path(host_python_dir)
+        candidates.extend(
+            [
+                host_dir,
+                host_dir.parent,
+                host_dir.parent.parent,
+                host_dir.parent.parent.parent,
+                host_dir.parent.parent / "resources" / "ComfyUI",
+            ]
+        )
+
+    local_appdata = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    candidates.append(local_appdata / "Programs" / "ComfyUI" / "resources" / "ComfyUI")
+
+    cwd = Path.cwd()
+    candidates.extend([cwd, *list(cwd.parents)[:4]])
+
+    here = Path(__file__).resolve()
+    candidates.extend(list(here.parents)[:6])
+
+    unique_candidates: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except Exception:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique_candidates.append(resolved)
+    return unique_candidates
+
+
+def ensure_comfyui_base() -> Path | None:
+    """Add the ComfyUI core directory to sys.path if it can be located."""
+    for candidate in _candidate_paths():
+        if not _is_comfyui_base(candidate):
+            continue
+
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+        os.environ.setdefault("COMFYUI_BASE", candidate_str)
+        return candidate
+
+    return None


### PR DESCRIPTION
## Summary
- bootstrap the real ComfyUI core path before egister_nodes() runs
- do the same bootstrap inside the isolated 
odes package so older_paths, comfy_api, and other ComfyUI modules resolve under desktop installs
- keep the change local to import/bootstrap logic without changing node behavior

## Problem
On desktop ComfyUI installs, comfy-env isolation can scan comfyui-sam3 before the ComfyUI core path is available on sys.path. That causes imports like older_paths to fail during metadata scan, so the node registers 0 nodes even though dependencies are installed.

## Validation
- reproduced the failure locally from a desktop ComfyUI installation layout
- verified the patched package imports successfully through egister_nodes()
- confirmed local registration reports 15 SAM3 nodes after the fix