### PR TITLE
fix: hide internal widgets in Nodes 2.0 (vueNodes)

### DIFF
--- a/web/sam3_bbox_widget.js
+++ b/web/sam3_bbox_widget.js
@@ -21,7 +21,10 @@ function hideWidgetForGood(node, widget, suffix = '') {
     // Multiple hiding approaches to ensure widget is fully hidden
     widget.computeSize = () => [0, -4];  // -4 compensates for litegraph's automatic widget gap
     widget.type = "converted-widget" + suffix;
-    widget.hidden = true;  // Mark as hidden
+    widget.hidden = true;  // Mark as hidden (legacy LiteGraph canvas renderer)
+    // Nodes 2.0 (vueNodes) reads hidden from widget.options.hidden, not the top-level flag
+    widget.options = widget.options || {};
+    widget.options.hidden = true;
 
     // IMPORTANT: Keep serialization enabled so values are sent to backend
     // (We just hide it visually, but it still needs to send data)

--- a/web/sam3_interactive_widget.js
+++ b/web/sam3_interactive_widget.js
@@ -26,6 +26,9 @@ function hideWidgetForGood(node, widget, suffix = '') {
     widget.computeSize = () => [0, -4];
     widget.type = "converted-widget" + suffix;
     widget.hidden = true;
+    // Nodes 2.0 (vueNodes) reads hidden from widget.options.hidden, not the top-level flag
+    widget.options = widget.options || {};
+    widget.options.hidden = true;
     if (widget.element) {
         widget.element.style.display = "none";
         widget.element.style.visibility = "hidden";

--- a/web/sam3_multiregion_widget.js
+++ b/web/sam3_multiregion_widget.js
@@ -30,6 +30,9 @@ function hideWidgetForGood(node, widget, suffix = '') {
     widget.computeSize = () => [0, -4];
     widget.type = "converted-widget" + suffix;
     widget.hidden = true;
+    // Nodes 2.0 (vueNodes) reads hidden from widget.options.hidden, not the top-level flag
+    widget.options = widget.options || {};
+    widget.options.hidden = true;
     if (widget.element) {
         widget.element.style.display = "none";
         widget.element.style.visibility = "hidden";

--- a/web/sam3_points_widget.js
+++ b/web/sam3_points_widget.js
@@ -21,7 +21,10 @@ function hideWidgetForGood(node, widget, suffix = '') {
     // Multiple hiding approaches to ensure widget is fully hidden
     widget.computeSize = () => [0, -4];  // -4 compensates for litegraph's automatic widget gap
     widget.type = "converted-widget" + suffix;
-    widget.hidden = true;  // Mark as hidden
+    widget.hidden = true;  // Mark as hidden (legacy LiteGraph canvas renderer)
+    // Nodes 2.0 (vueNodes) reads hidden from widget.options.hidden, not the top-level flag
+    widget.options = widget.options || {};
+    widget.options.hidden = true;
 
     // IMPORTANT: Keep serialization enabled so values are sent to backend
     // (We just hide it visually, but it still needs to send data)


### PR DESCRIPTION
hideWidgetForGood relied on widget.type = "converted-widget" and the top-level widget.hidden flag, which the legacy LiteGraph canvas renderer honors. 
<img width="1650" height="784" alt="image" src="https://github.com/user-attachments/assets/1befda07-897e-4062-9d17-98f68b522088" />

The new Vue-based node renderer reads hidden from widget.options.hidden, so these internal storage widgets (points_store, coordinates, bboxes, multi_region_store, etc.) became visible to users on Nodes 2.0. Also set widget.options.hidden = true so both renderers hide them.