### PR TITLE
fix: stop right-click bubbling to node context menu in Nodes 2.0

### DIFF
--- a/web/sam3_bbox_widget.js
+++ b/web/sam3_bbox_widget.js
@@ -287,6 +287,7 @@ app.registerExtension({
 
                 canvas.addEventListener("contextmenu", (e) => {
                     e.preventDefault();
+                    e.stopPropagation();
                     // Trigger mousedown with right button flag
                     canvas.dispatchEvent(new MouseEvent('mousedown', {
                         button: 2,

--- a/web/sam3_interactive_widget.js
+++ b/web/sam3_interactive_widget.js
@@ -281,6 +281,7 @@ app.registerExtension({
 
             canvas.addEventListener("contextmenu", (e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 canvas.dispatchEvent(new MouseEvent('mousedown', {
                     button: 2,
                     clientX: e.clientX,

--- a/web/sam3_multiregion_widget.js
+++ b/web/sam3_multiregion_widget.js
@@ -248,6 +248,7 @@ app.registerExtension({
 
             canvas.addEventListener("contextmenu", (e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 canvas.dispatchEvent(new MouseEvent('mousedown', {
                     button: 2,
                     clientX: e.clientX,

--- a/web/sam3_points_widget.js
+++ b/web/sam3_points_widget.js
@@ -227,6 +227,7 @@ app.registerExtension({
 
                 canvas.addEventListener("contextmenu", (e) => {
                     e.preventDefault();
+                    e.stopPropagation();
                     // Trigger click with right button flag
                     canvas.dispatchEvent(new MouseEvent('click', {
                         button: 2,


### PR DESCRIPTION
The canvas contextmenu listeners in the Point/BBox/MultiRegion/ Interactive collectors called e.preventDefault() but not e.stopPropagation(). Under LiteGraph this was sufficient because the DOM widget canvas absorbed the event. Under Nodes 2.0 (vueNodes) the event bubbles to NodeWidgets.vue's @contextmenu handler, which opens the node's context menu and blocks negative-point/bbox interaction. 
<img width="694" height="1168" alt="image" src="https://github.com/user-attachments/assets/e277a8ca-f6f4-408f-8fbd-e9317db57c39" />

Adding stopPropagation keeps the right-click confined to the canvas.